### PR TITLE
Add helpful account management features: Getting help when forgetting username or password

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,7 +21,7 @@ import { ProfilePageResolver } from './resolvers';
 const routes: Routes = [
   {
     path: '',
-    redirectTo: '/home',
+    redirectTo: 'home',
     pathMatch: 'full',
   },
   {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit } from '@angular/core';
 import { transition, animate, query, style, trigger, group } from '@angular/animations';
 import { NavigationEnd, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
 
 import { environment } from 'src/environments/environment';
-import { TrackingService, AccountService, SnackbarService } from './services';
+import { TrackingService, AccountService, SnackbarService, QueryActionService } from './services';
 
 @Component({
   selector: 'app-root',
@@ -29,7 +29,7 @@ import { TrackingService, AccountService, SnackbarService } from './services';
     ]),
   ],
 })
-export class AppComponent implements OnInit {
+export class AppComponent implements OnInit, AfterViewInit {
   title = 'Kompakkt';
   constructor(
     private tracking: TrackingService,
@@ -37,6 +37,7 @@ export class AppComponent implements OnInit {
     private router: Router,
     private account: AccountService,
     private snackbar: SnackbarService,
+    private queryAction: QueryActionService,
   ) {
     translate.setDefaultLang('en');
     translate.use('en');
@@ -61,5 +62,9 @@ export class AppComponent implements OnInit {
         }
       });
     }
+  }
+
+  ngAfterViewInit() {
+    this.queryAction.evaluateAction();
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -102,6 +102,9 @@ import {
   EditEntityDialogComponent,
   PasswordProtectedDialogComponent,
 } from './dialogs';
+import { ResetPasswordDialogComponent } from './dialogs/reset-password-dialog/reset-password-dialog.component';
+import { ForgotUsernameDialogComponent } from './dialogs/forgot-username-dialog/forgot-username-dialog.component';
+import { ForgotPasswordDialogComponent } from './dialogs/forgot-password-dialog/forgot-password-dialog.component';
 
 const createTranslateLoader = (http: HttpClient) => {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
@@ -154,6 +157,9 @@ const createTranslateLoader = (http: HttpClient) => {
     DetailPersonComponent,
     DetailInstitutionComponent,
     FilesizePipe,
+    ResetPasswordDialogComponent,
+    ForgotUsernameDialogComponent,
+    ForgotPasswordDialogComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/components/actionbar/actionbar.component.html
+++ b/src/app/components/actionbar/actionbar.component.html
@@ -25,7 +25,7 @@
     <button *ngIf="!isUploader" mat-flat-button color="primary" (click)="openUploadApplication()">
       Request upload capabilities
     </button>
-    <button *ngIf="uploadRequested()" mat-flat-button color="primary">
+    <button *ngIf="hasRequestedUpload" mat-flat-button color="primary">
       Upload capabilities requested
     </button>
     <ng-container *ngIf="isUploader">

--- a/src/app/components/actionbar/actionbar.component.ts
+++ b/src/app/components/actionbar/actionbar.component.ts
@@ -262,9 +262,9 @@ export class ActionbarComponent {
     return this.userData?.role === UserRank.admin || this.userData?.role === UserRank.uploader;
   }
 
-  public uploadRequested() {
+  get hasRequestedUpload() {
     if (!this.userData) return false;
-    return this.userData.role === UserRank.uploadrequested;
+    return this.userData?.role === UserRank.uploadrequested;
   }
 
   public toggleSlide() {

--- a/src/app/components/auth-dialog/auth-dialog.component.html
+++ b/src/app/components/auth-dialog/auth-dialog.component.html
@@ -1,38 +1,31 @@
-<form action="auth-dialog_submit" method="get" accept-charset="utf-8">
-  <h1 mat-dialog-title>{{ concern && concern !== '' ? concern : 'Login' }}</h1>
-  <div mat-dialog-content>
-    <mat-form-field>
-      <input
-        id="username"
-        autocomplete="username"
-        placeholder="Username"
-        type="username"
-        matInput
-        [(ngModel)]="data.username"
-        [ngModelOptions]="{ standalone: true }"
-      />
-    </mat-form-field>
-  </div>
-  <div mat-dialog-content>
-    <mat-form-field>
-      <input
-        id="password"
-        autocomplete="password"
-        placeholder="Password"
-        type="password"
-        matInput
-        [(ngModel)]="data.password"
-        [ngModelOptions]="{ standalone: true }"
-      />
-    </mat-form-field>
-  </div>
-  <div id="login-failed" mat-dialog-content *ngIf="loginFailed">
-    Failed to login.<br />Check username and password.
-  </div>
-  <div mat-dialog-actions>
+<form [formGroup]="form" (submit)="trySubmit()">
+  <h3>{{ concern !== '' ? concern : 'Login' }}</h3>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Enter your username"
+      type="text"
+      autocomplete="username"
+      name="username"
+      formControlName="username"
+      required
+    />
+  </mat-form-field>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Enter your password"
+      type="password"
+      autocomplete="current-password"
+      name="password"
+      formControlName="password"
+      required
+    />
+  </mat-form-field>
+  <div class="button-row">
     <button
       id="btn-cancel"
-      mat-button
+      mat-stroked-button
       type="button"
       (click)="dialogRef.close(false)"
       [disabled]="waitingForResponse"
@@ -41,13 +34,27 @@
     </button>
     <button
       id="btn-login"
-      mat-raised-button
+      mat-stroked-button
       type="submit"
-      (click)="clickedLogin()"
       color="primary"
-      [disabled]="data.username.length === 0 || data.password.length === 0 || waitingForResponse"
+      [disabled]="!form.valid || waitingForResponse"
     >
       Login
     </button>
   </div>
+  <p>
+    Don't have an account?
+    <a href="javascript:void(0)" (click)="openRegistrationDialog()">Register</a>
+  </p>
 </form>
+<div class="errors" *ngIf="loginFailed">Failed to login.<br />Check username and password.</div>
+
+<hr />
+
+<div class="help">
+  <h3>Need help?</h3>
+  <div class="help-row">
+    <a href="javascript:void(0)" (click)="openForgotUsernameDialog()">Forgot username?</a>
+    <a href="javascript:void(0)" (click)="openForgotPasswordDialog()">Forgot password?</a>
+  </div>
+</div>

--- a/src/app/components/auth-dialog/auth-dialog.component.scss
+++ b/src/app/components/auth-dialog/auth-dialog.component.scss
@@ -1,27 +1,26 @@
 form {
-  padding: 1.5rem;
-  max-width: 30vw;
-  overflow-x: hidden;
-  overflow-y: auto;
+  margin-bottom: 1.6rem;
+}
 
-  > .mat-dialog-title {
-    overflow-wrap: break-word;
-    font-size: medium;
-  }
+.button-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
+}
 
-  .mat-dialog-content {
-    .mat-form-field {
-      width: 100%;
-    }
-  }
+.errors {
+  color: red;
+  text-align: center;
+}
 
-  .mat-dialog-actions {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+.help {
+  .help-row {
+    display: flex;
+    justify-content: space-around;
   }
 }
 
-#login-failed {
-  color: red;
-  text-align: center;
+h3 {
+  border-left: solid var(--brand-color) 0.25rem;
+  padding-left: 0.8rem;
 }

--- a/src/app/components/auth-dialog/auth-dialog.component.ts
+++ b/src/app/components/auth-dialog/auth-dialog.component.ts
@@ -1,30 +1,40 @@
-import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-import { AccountService } from 'src/app/services';
+import { AccountService } from '~services';
+import {
+  ForgotPasswordDialogComponent,
+  ForgotUsernameDialogComponent,
+  RegisterDialogComponent,
+} from '~dialogs';
 
 @Component({
   selector: 'app-auth-dialog',
   templateUrl: './auth-dialog.component.html',
   styleUrls: ['./auth-dialog.component.scss'],
 })
-export class AuthDialogComponent {
+export class AuthDialogComponent implements OnInit {
   public waitingForResponse = false;
   public loginFailed = false;
 
-  public data = {
-    username: '',
-    password: '',
-  };
+  public form = new FormGroup({
+    username: new FormControl('', Validators.required),
+    password: new FormControl('', Validators.required),
+  });
 
   constructor(
     public dialogRef: MatDialogRef<AuthDialogComponent>,
     public account: AccountService,
-    @Inject(MAT_DIALOG_DATA) public concern: string,
+    private dialog: MatDialog,
+    @Inject(MAT_DIALOG_DATA) public data?: { concern?: string; username?: string },
   ) {}
 
-  public async clickedLogin() {
-    const { username, password } = this.data;
+  public async trySubmit() {
+    const { username, password } = {
+      username: this.form.get('username')!.value as string,
+      password: this.form.get('password')!.value as string,
+    };
 
     this.waitingForResponse = true;
     this.dialogRef.disableClose = true;
@@ -38,5 +48,25 @@ export class AuthDialogComponent {
     if (!success) return;
 
     this.dialogRef.close({ username, password });
+  }
+
+  public openForgotUsernameDialog() {
+    this.dialog.open(ForgotUsernameDialogComponent);
+  }
+
+  public openForgotPasswordDialog() {
+    this.dialog.open(ForgotPasswordDialogComponent);
+  }
+
+  public openRegistrationDialog() {
+    this.dialog.open(RegisterDialogComponent);
+  }
+
+  get concern() {
+    return this.data?.concern ?? '';
+  }
+
+  ngOnInit() {
+    if (this.data?.username) this.form.get('username')?.patchValue(this.data.username);
   }
 }

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
@@ -1,0 +1,23 @@
+<form [formGroup]="form" (submit)="trySubmit()">
+  <h3>Forgot your password?</h3>
+  <p>You can request your password using your username<br />and will receive a mail!</p>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Enter your username"
+      type="text"
+      autocomplete="username"
+      name="username"
+      formControlName="username"
+      required
+    />
+  </mat-form-field>
+
+  <button mat-stroked-button type="submit" color="primary" [disabled]="!form.valid">
+    Submit password request
+  </button>
+</form>
+
+<p class="errors" *ngIf="serverErrorMsg.length > 0">
+  {{ serverErrorMsg }}
+</p>

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.scss
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.scss
@@ -1,0 +1,12 @@
+button {
+  width: 100%;
+}
+
+.errors {
+  color: red;
+}
+
+h3 {
+  border-left: solid var(--brand-color) 0.25rem;
+  padding-left: 0.8rem;
+}

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.ts
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { BackendService, SnackbarService } from '~services';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Component({
+  selector: 'app-forgot-password-dialog',
+  templateUrl: './forgot-password-dialog.component.html',
+  styleUrls: ['./forgot-password-dialog.component.scss'],
+})
+export class ForgotPasswordDialogComponent implements OnInit {
+  public form = new FormGroup({
+    username: new FormControl('', Validators.required),
+  });
+
+  public serverErrorMsg = '';
+
+  constructor(
+    private backend: BackendService,
+    private snackbar: SnackbarService,
+    private dialogRef: MatDialogRef<ForgotPasswordDialogComponent>,
+  ) {}
+
+  public async trySubmit() {
+    const username = this.form.get('username')!.value as string;
+
+    this.backend
+      .requestPasswordReset(username)
+      .then(() => {
+        this.snackbar.showInfo('Your password reset link has been sent to your mail!');
+        this.dialogRef.close(true);
+      })
+      .catch((error: HttpErrorResponse) => (this.serverErrorMsg = error.error.toString()));
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
@@ -1,0 +1,23 @@
+<form [formGroup]="form" (submit)="trySubmit()">
+  <h3>Forgot your username?</h3>
+  <p>You can request your username using your mail address!</p>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Enter your mail address"
+      type="text"
+      autocomplete="email"
+      name="mail"
+      formControlName="mail"
+      required
+    />
+  </mat-form-field>
+
+  <button mat-stroked-button type="submit" color="primary" [disabled]="!form.valid">
+    Send mail
+  </button>
+</form>
+
+<p class="errors" *ngIf="serverErrorMsg.length > 0">
+  {{ serverErrorMsg }}
+</p>

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.scss
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.scss
@@ -1,0 +1,12 @@
+button {
+  width: 100%;
+}
+
+.errors {
+  color: red;
+}
+
+h3 {
+  border-left: solid var(--brand-color) 0.25rem;
+  padding-left: 0.8rem;
+}

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.ts
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { BackendService, SnackbarService } from '~services';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Component({
+  selector: 'app-forgot-username-dialog',
+  templateUrl: './forgot-username-dialog.component.html',
+  styleUrls: ['./forgot-username-dialog.component.scss'],
+})
+export class ForgotUsernameDialogComponent implements OnInit {
+  public form = new FormGroup({
+    mail: new FormControl('', Validators.email),
+  });
+
+  public serverErrorMsg = '';
+
+  constructor(
+    private backend: BackendService,
+    private snackbar: SnackbarService,
+    private dialogRef: MatDialogRef<ForgotUsernameDialogComponent>,
+  ) {}
+
+  public async trySubmit() {
+    const mail = this.form.get('mail')!.value as string;
+
+    this.backend
+      .forgotUsername(mail)
+      .then(() => {
+        this.snackbar.showInfo('Your username has been sent to your mail!');
+        this.dialogRef.close(true);
+      })
+      .catch((error: HttpErrorResponse) => (this.serverErrorMsg = error.error.toString()));
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/dialogs/index.ts
+++ b/src/app/dialogs/index.ts
@@ -9,3 +9,4 @@ export { PasswordProtectedDialogComponent } from './password-protected-dialog/pa
 export { RegisterDialogComponent } from './register-dialog/register-dialog.component';
 export { UploadApplicationDialogComponent } from './upload-application-dialog/upload-application-dialog.component';
 export { ResetPasswordDialogComponent } from './reset-password-dialog/reset-password-dialog.component';
+export { ForgotUsernameDialogComponent } from './forgot-username-dialog/forgot-username-dialog.component';

--- a/src/app/dialogs/index.ts
+++ b/src/app/dialogs/index.ts
@@ -8,3 +8,4 @@ export { GroupMemberDialogComponent } from './group-member-dialog/group-member-d
 export { PasswordProtectedDialogComponent } from './password-protected-dialog/password-protected-dialog.component';
 export { RegisterDialogComponent } from './register-dialog/register-dialog.component';
 export { UploadApplicationDialogComponent } from './upload-application-dialog/upload-application-dialog.component';
+export { ResetPasswordDialogComponent } from './reset-password-dialog/reset-password-dialog.component';

--- a/src/app/dialogs/index.ts
+++ b/src/app/dialogs/index.ts
@@ -10,3 +10,4 @@ export { RegisterDialogComponent } from './register-dialog/register-dialog.compo
 export { UploadApplicationDialogComponent } from './upload-application-dialog/upload-application-dialog.component';
 export { ResetPasswordDialogComponent } from './reset-password-dialog/reset-password-dialog.component';
 export { ForgotUsernameDialogComponent } from './forgot-username-dialog/forgot-username-dialog.component';
+export { ForgotPasswordDialogComponent } from './forgot-password-dialog/forgot-password-dialog.component';

--- a/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.html
+++ b/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.html
@@ -1,0 +1,45 @@
+<form [formGroup]="form" (submit)="trySubmit()">
+  <h3>Choose a new password</h3>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Username"
+      type="text"
+      autocomplete="username"
+      name="username"
+      formControlName="username"
+      required
+    />
+  </mat-form-field>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="New password"
+      type="password"
+      autocomplete="new-password"
+      name="password"
+      formControlName="password"
+      required
+    />
+  </mat-form-field>
+  <mat-form-field class="fullwidth">
+    <input
+      matInput
+      placeholder="Repeat new password"
+      type="password"
+      autocomplete="new-password"
+      name="password-repeat"
+      formControlName="passwordRepeat"
+      required
+    />
+  </mat-form-field>
+  <div class="bottom-row">
+    <span class="errors">
+      <ng-container *ngIf="form.errors?.not_equal"> Passwords are not equal </ng-container>
+      <ng-container *ngIf="serverErrorMsg.length > 0">{{ serverErrorMsg }}</ng-container>
+    </span>
+    <button mat-stroked-button color="accent" type="submit" [disabled]="!form.valid">
+      Change your password
+    </button>
+  </div>
+</form>

--- a/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.scss
+++ b/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.scss
@@ -1,0 +1,15 @@
+div.bottom-row {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.errors {
+  color: red;
+}
+
+h3 {
+  border-left: solid var(--brand-color) 0.25rem;
+  padding-left: 0.8rem;
+}

--- a/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.ts
+++ b/src/app/dialogs/reset-password-dialog/reset-password-dialog.component.ts
@@ -1,0 +1,61 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, OnInit, Inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+import { BackendService, SnackbarService } from '~services';
+
+@Component({
+  selector: 'app-reset-password-dialog',
+  templateUrl: './reset-password-dialog.component.html',
+  styleUrls: ['./reset-password-dialog.component.scss'],
+})
+export class ResetPasswordDialogComponent implements OnInit {
+  public form = new FormGroup(
+    {
+      username: new FormControl('', Validators.required),
+      password: new FormControl('', Validators.required),
+      passwordRepeat: new FormControl('', Validators.required),
+    },
+    control => {
+      const password = control.get('password');
+      const passwordRepeat = control.get('passwordRepeat');
+
+      if (!password?.touched && !passwordRepeat?.touched) return null;
+
+      if (password?.value !== passwordRepeat?.value) return { not_equal: 'Passwords do not match' };
+
+      return null;
+    },
+  );
+
+  public serverErrorMsg: string = '';
+
+  constructor(
+    public dialogRef: MatDialogRef<ResetPasswordDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: { token: string },
+    private backend: BackendService,
+    private snackbar: SnackbarService,
+  ) {}
+
+  public trySubmit() {
+    const { username, token, password } = {
+      username: this.form.get('username')!.value as string,
+      password: this.form.get('password')!.value as string,
+      token: this.data.token,
+    };
+
+    this.backend
+      .confirmPasswordResetRequest(username, token, password)
+      .then(() => {
+        this.snackbar.showInfo('Your new password has been set! Try to log in!');
+        this.dialogRef.close();
+      })
+      .catch((error: HttpErrorResponse) => {
+        console.log(error);
+        this.serverErrorMsg = error.error.toString();
+      });
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.html
+++ b/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.html
@@ -1,97 +1,127 @@
-<form [formGroup]="uploadApplicationForm" (submit)="trySend()">
+<ng-container *ngIf="requestSuccess; else showForm">
   <div class="metadata-nested">
-    <h1>Upload application form</h1>
-    <p>You currently do not have upload rights.</p>
-    <p>
-      Before being allowed to upload objects to the Kompakkt platform, we want to hear your
-      motivations.
-    </p>
+    <h1>Success!</h1>
   </div>
-
   <div class="metadata-nested">
-    <h3>What's your motivation for using Kompakkt?</h3>
-    <mat-form-field>
-      <textarea
-        matInput
-        placeholder="Motivation"
-        name="motivation"
-        formControlName="motivation"
-      ></textarea>
-    </mat-form-field>
+    <p>We received your request for upload capabilities and will get to it soon!</p>
+    <p>Until then, feel free to explore existing objects on Kompakkt.</p>
   </div>
-
   <div class="metadata-nested">
-    <div>
-      <h3>Are you using Kompakkt as part of an institution or university?</h3>
-      <span class="slider-container"> No <mat-slide-toggle #slider></mat-slide-toggle> Yes </span>
+    <button mat-raised-button (click)="dialogRef.close()" color="accent">Close</button>
+  </div>
+</ng-container>
+<ng-template #showForm>
+  <form [formGroup]="uploadApplicationForm" (submit)="trySend()">
+    <div class="metadata-nested">
+      <h1>Upload application form</h1>
+      <p>You currently do not have upload capabilities.</p>
+      <p>
+        Before being allowed to upload objects to the Kompakkt platform, we want to hear your
+        motivations.
+      </p>
     </div>
 
-    <div *ngIf="slider.checked" class="address-input">
-      <mat-form-field class="fullwidth">
-        <input
+    <div class="metadata-nested">
+      <h3>What's your motivation for using Kompakkt?</h3>
+      <mat-form-field>
+        <textarea
           matInput
-          placeholder="University"
-          type="text"
-          name="university"
-          formControlName="university"
-        />
+          placeholder="Motivation"
+          name="motivation"
+          formControlName="motivation"
+        ></textarea>
       </mat-form-field>
-      <mat-form-field class="fullwidth">
-        <input
-          matInput
-          placeholder="Institution"
-          type="text"
-          name="institution"
-          formControlName="institution"
-        />
-      </mat-form-field>
-      <div [formGroup]="address">
-        <mat-form-field>
+    </div>
+
+    <div class="metadata-nested">
+      <div>
+        <h3>Are you using Kompakkt as part of an institution or university?</h3>
+        <span class="slider-container"> No <mat-slide-toggle #slider></mat-slide-toggle> Yes </span>
+      </div>
+
+      <div *ngIf="slider.checked" class="address-input">
+        <mat-form-field class="fullwidth">
           <input
             matInput
-            placeholder="Country"
+            placeholder="University"
             type="text"
-            name="country"
-            formControlName="country"
+            name="university"
+            formControlName="university"
           />
         </mat-form-field>
-
-        <mat-form-field>
-          <input matInput placeholder="City" type="text" name="city" formControlName="city" />
-        </mat-form-field>
-
-        <mat-form-field>
+        <mat-form-field class="fullwidth">
           <input
             matInput
-            placeholder="Postal code"
+            placeholder="Institution"
             type="text"
-            name="postcode"
-            formControlName="postcode"
+            name="institution"
+            formControlName="institution"
           />
         </mat-form-field>
+        <div [formGroup]="address">
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Country"
+              type="text"
+              name="country"
+              formControlName="country"
+            />
+          </mat-form-field>
 
-        <mat-form-field>
-          <input matInput placeholder="Street" type="text" name="street" formControlName="street" />
-        </mat-form-field>
+          <mat-form-field>
+            <input matInput placeholder="City" type="text" name="city" formControlName="city" />
+          </mat-form-field>
 
-        <mat-form-field>
-          <input matInput placeholder="Number" type="text" name="number" formControlName="number" />
-        </mat-form-field>
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Postal code"
+              type="text"
+              name="postcode"
+              formControlName="postcode"
+            />
+          </mat-form-field>
 
-        <mat-form-field>
-          <input
-            matInput
-            placeholder="Building"
-            type="text"
-            name="building"
-            formControlName="building"
-          />
-        </mat-form-field>
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Street"
+              type="text"
+              name="street"
+              formControlName="street"
+            />
+          </mat-form-field>
+
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Number"
+              type="text"
+              name="number"
+              formControlName="number"
+            />
+          </mat-form-field>
+
+          <mat-form-field>
+            <input
+              matInput
+              placeholder="Building"
+              type="text"
+              name="building"
+              formControlName="building"
+            />
+          </mat-form-field>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="metadata-nested">
-    <button mat-raised-button color="accent" type="submit">Submit request</button>
-  </div>
-</form>
+    <div class="metadata-nested">
+      <button mat-raised-button color="accent" type="submit">Submit request</button>
+    </div>
+
+    <div class="metadata-nested error" *ngIf="errorMsg.length > 0">
+      <p>{{ errorMsg }}</p>
+    </div>
+  </form>
+</ng-template>

--- a/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.scss
+++ b/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.scss
@@ -15,6 +15,9 @@ mat-form-field {
     width: 100%;
     height: 100%;
   }
+  & + .metadata-nested {
+    margin-top: 1rem;
+  }
 }
 
 .address-input {

--- a/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.ts
+++ b/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.ts
@@ -68,31 +68,32 @@ export class UploadApplicationDialogComponent implements OnInit {
   }
 
   public trySend() {
-    if (!this.uploadApplicationForm.valid) {
-      return;
-    }
+    if (!this.uploadApplicationForm.valid) return;
     const val = this.uploadApplicationForm.getRawValue();
     const { motivation, prename, surname, mail, institution, university, address } = val;
 
-    this.backend
-      .sendUploadApplicationMail({
-        subject: `[UPLOAD] ${prename} ${surname} - ${mail}`,
-        mailbody: `
+    const subject = `[UPLOAD] ${prename} ${surname} - ${mail}`;
+    let mailbody = `
 Upload application request
 Prename: ${prename}
 Surname: ${surname}
-Mail:    ${mail}
--
-Motivation:
-  ${motivation}
--
-Institution: ${institution}
-University:  ${university}
-Address:     ${address.country}
+Mail:    ${mail}\n`;
+
+    mailbody += 'Motivation:\n';
+
+    for (const line of motivation.split('\n')) mailbody += `> ${line}\n`;
+
+    if (institution.length > 0) mailbody += `\nInstitution: ${institution}`;
+    if (university.length > 0) mailbody += `\nUniversity: ${university}`;
+    if ((Object.values(address) as string[]).some(v => v.length > 0)) {
+      mailbody += `\nAddress:     ${address.country}
              ${address.postcode} ${address.city}
              ${address.street} ${address.number}
-             ${address.building}`.trim(),
-      })
+             ${address.building}`.trim();
+    }
+
+    this.backend
+      .sendUploadApplicationMail({ subject, mailbody })
       .then(() => (this.requestSuccess = true))
       .catch((error: HttpErrorResponse) => (this.errorMsg = error.error.toString()));
   }

--- a/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.ts
+++ b/src/app/dialogs/upload-application-dialog/upload-application-dialog.component.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 import { IUserData } from 'src/common';
 import { BackendService } from 'src/app/services';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'app-upload-application-dialog',
@@ -30,10 +31,14 @@ export class UploadApplicationDialogComponent implements OnInit {
     motivation: new FormControl('', Validators.required),
   });
 
+  public errorMsg: string = '';
+
+  public requestSuccess = false;
+
   constructor(
     private backend: BackendService,
     @Inject(MAT_DIALOG_DATA) public data: IUserData | undefined,
-    private dialogRef: MatDialogRef<UploadApplicationDialogComponent>,
+    public dialogRef: MatDialogRef<UploadApplicationDialogComponent>,
   ) {}
 
   get prename() {
@@ -88,7 +93,7 @@ Address:     ${address.country}
              ${address.street} ${address.number}
              ${address.building}`.trim(),
       })
-      .then(result => this.dialogRef.close())
-      .catch(error => console.error(error));
+      .then(() => (this.requestSuccess = true))
+      .catch((error: HttpErrorResponse) => (this.errorMsg = error.error.toString()));
   }
 }

--- a/src/app/services/backend.service.ts
+++ b/src/app/services/backend.service.ts
@@ -383,7 +383,7 @@ export class BackendService {
     return this.get(`utility/finduserinmetadata`);
   }
 
-  // Auth
+  // User-management
   public async login(username: string, password: string): Promise<IUserData> {
     return this.post(`user-management/login`, { username, password });
   }
@@ -394,5 +394,21 @@ export class BackendService {
 
   public async isAuthorized(): Promise<IUserData> {
     return this.get(`user-management/auth`);
+  }
+
+  public async requestPasswordReset(username: string): Promise<any> {
+    return this.post(`user-management/help/request-reset`, { username });
+  }
+
+  public async confirmPasswordResetRequest(
+    username: string,
+    token: string,
+    password: string,
+  ): Promise<any> {
+    return this.post(`user-management/help/confirm-reset`, { username, token, password });
+  }
+
+  public async forgotUsername(mail: string): Promise<any> {
+    return this.post(`user-management/help/forgot-username`, { mail });
   }
 }

--- a/src/app/services/index.ts
+++ b/src/app/services/index.ts
@@ -22,3 +22,4 @@ export {
   videoExts,
   UploadHandlerService,
 } from './upload-handler.service';
+export { QueryActionService } from './query-action.service';

--- a/src/app/services/query-action.service.ts
+++ b/src/app/services/query-action.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+
+import { AuthDialogComponent } from '~components';
+import { ResetPasswordDialogComponent } from '~dialogs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class QueryActionService {
+  private location = window.location;
+  private url = new URL(this.location.href);
+
+  constructor(private dialog: MatDialog) {}
+
+  get search() {
+    return this.url.searchParams;
+  }
+
+  public evaluateAction() {
+    const action = this.search.get('action');
+    if (!action) return;
+
+    switch (action) {
+      case 'login':
+        return this.loginAction();
+      case 'passwordreset':
+        return this.passwordResetAction();
+    }
+  }
+
+  private loginAction() {
+    const username = this.search.get('username');
+    const dialog = this.dialog.open(AuthDialogComponent, {
+      data: { username },
+      disableClose: true,
+    });
+    firstValueFrom(dialog.afterClosed()).then(() => {
+      this.removeParams();
+    });
+  }
+
+  private passwordResetAction() {
+    const token = this.search.get('token');
+    const dialog = this.dialog.open(ResetPasswordDialogComponent, {
+      data: { token },
+      disableClose: true,
+    });
+    firstValueFrom(dialog.afterClosed()).then(() => {
+      this.removeParams();
+      this.dialog.open(AuthDialogComponent, { disableClose: true });
+    });
+  }
+
+  private removeParams() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('token');
+    url.searchParams.delete('username');
+    url.searchParams.delete('action');
+    window.history.pushState(null, '', url.toString());
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,7 @@
     'Gill Sans MT', 'Myriad Pro', Myriad, 'DejaVu Sans Condensed', 'Liberation Sans',
     'Nimbus Sans L', Tahoma, Geneva, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --drop-shadow: drop-shadow(0 0.1rem 0.1rem rgba(0, 0, 0, 0.25));
+  --brand-color: #00afe7;
 }
 
 /* Font smoothing */
@@ -101,7 +102,7 @@ h5 {
 .mat-flat-button.mat-primary,
 .mat-mini-fab.mat-primary,
 .mat-raised-button.mat-primary {
-  background-color: #00afe7;
+  background-color: var(--brand-color);
 }
 
 .mat-horizontal-stepper-header {
@@ -111,7 +112,7 @@ h5 {
   &:hover,
   &:active {
     background-color: rgba(0, 0, 0, 0) !important;
-    border-bottom: 0.2rem solid #00afe7 !important;
+    border-bottom: 0.2rem solid var(--brand-color) !important;
   }
 
   margin-bottom: 12px;
@@ -139,7 +140,7 @@ h1.entity-detail {
 }
 
 a {
-  color: #00afe7;
+  color: var(--brand-color);
 }
 
 .content {
@@ -161,11 +162,11 @@ iframe {
 }
 
 .text-blue {
-  color: #00afe7;
+  color: var(--brand-color);
 }
 
 .bgr-blue {
-  background-color: #00afe7;
+  background-color: var(--brand-color);
 }
 
 .bgr-white {
@@ -220,7 +221,7 @@ iframe {
   .metadata-mat-card-buttons {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-    border-top: solid 0.1rem #00afe7;
+    border-top: solid 0.1rem var(--brand-color);
   }
 
   .metadata-mat-card-content {
@@ -238,7 +239,7 @@ iframe {
   transition: border 280ms cubic-bezier(0.4, 0, 0.2, 1),
     box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1) !important;
 
-  --color: #00afe7;
+  --color: var(--brand-color);
   &.error {
     --color: red;
   }
@@ -399,7 +400,7 @@ app-actionbar {
 
   h1,
   h2 {
-    color: #00afe7;
+    color: var(--brand-color);
   }
 }
 
@@ -518,7 +519,7 @@ app-annotate {
   }
 
   .mat-expansion-panel-header {
-    border-top: solid 2px #00afe7 !important;
+    border-top: solid 2px var(--brand-color) !important;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -238,6 +238,11 @@ iframe {
   transition: border 280ms cubic-bezier(0.4, 0, 0.2, 1),
     box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1) !important;
 
+  --color: #00afe7;
+  &.error {
+    --color: red;
+  }
+
   > mat-form-field {
     width: 100%;
   }
@@ -246,7 +251,7 @@ iframe {
 
   &:focus-within,
   &:hover {
-    border-left: 3px solid #00afe7;
+    border-left: 3px solid var(--color);
   }
 
   .metadata-nested:focus-within {


### PR DESCRIPTION
Previously, users were unable to request a password reset or retrieve their username, preventing some users from accessing Kompakkt.
This pull request addresses the missing features (as noted in https://github.com/Kompakkt/Kompakkt/issues/7), by adding several new dialogs to the frontend.

During the login step, the user is now offered two additional links,
one to retrieve their username and one to retrieve their password.
The decision to turn this into two separate dialogs instead of a single one was to keep the associated functions on the server more organized.
![Screenshot_2022-07-07_18-45-44](https://user-images.githubusercontent.com/1042382/177828370-b621107e-01c6-4814-8e34-8d3eaac320ef.png)

The username can be requested via mail and on successful request the user gets feedback via the snackbar.
![Screenshot_2022-07-07_18-46-31](https://user-images.githubusercontent.com/1042382/177828395-f481df93-3b70-4ad2-8667-fbe8f885a4a1.png)
![Screenshot_2022-07-07_18-46-43](https://user-images.githubusercontent.com/1042382/177828410-dc4d767b-8030-4f09-8b05-e2281b122343.png)

The password can be requested via username and on successful request the user gets feedback via the snackbar.
![Screenshot_2022-07-07_18-47-33](https://user-images.githubusercontent.com/1042382/177828433-f0004b6f-165e-49e8-a6f6-8852cc5ac536.png)
![Screenshot_2022-07-07_18-48-08](https://user-images.githubusercontent.com/1042382/177828463-11c07106-76c5-4d8b-a8e3-8da74232c71f.png)


