### PR TITLE
Use Angular HttpInterceptors to better integrate with Angular HttpClient

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 // External dependencies
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouteReuseStrategy } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -106,6 +106,19 @@ import { ResetPasswordDialogComponent } from './dialogs/reset-password-dialog/re
 import { ForgotUsernameDialogComponent } from './dialogs/forgot-username-dialog/forgot-username-dialog.component';
 import { ForgotPasswordDialogComponent } from './dialogs/forgot-password-dialog/forgot-password-dialog.component';
 
+// Interceptors
+import { HttpOptionsInterceptor } from './services/interceptors/http-options-interceptor';
+import { RequestProgressInterceptor } from './services/interceptors/request-progress-interceptor';
+import { ExploreTimingInterceptor } from './services/interceptors/explore-timing-interceptor';
+import { HttpErrorInterceptor } from './services/interceptors/http-error-interceptor';
+
+const INTERCEPTORS: Provider[] = [
+  HttpErrorInterceptor,
+  HttpOptionsInterceptor,
+  RequestProgressInterceptor,
+  ExploreTimingInterceptor,
+].map(useClass => ({ provide: HTTP_INTERCEPTORS, multi: true, useClass }));
+
 const createTranslateLoader = (http: HttpClient) => {
   return new TranslateHttpLoader(http, './assets/i18n/', '.json');
 };
@@ -204,12 +217,7 @@ const createTranslateLoader = (http: HttpClient) => {
     }),
     ReactiveFormsModule,
   ],
-  providers: [
-    {
-      provide: RouteReuseStrategy,
-      useClass: RouteReuse,
-    },
-  ],
+  providers: [{ provide: RouteReuseStrategy, useClass: RouteReuse }, ...INTERCEPTORS],
   bootstrap: [AppComponent],
   entryComponents: [
     AuthDialogComponent,

--- a/src/app/services/backend.service.ts
+++ b/src/app/services/backend.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 
 import { environment } from 'src/environments/environment';
 import {
@@ -16,8 +17,6 @@ import {
   ObjectId,
   Collection,
 } from 'src/common';
-
-import { ProgressBarService } from './progress-bar.service';
 
 enum ETarget {
   contact = 'contact',
@@ -59,46 +58,15 @@ interface IExploreRequest {
 })
 export class BackendService {
   private endpoint = environment.server_url;
-  private httpOptions = {
-    headers: new HttpHeaders({
-      'Content-Type': 'application/json',
-    }),
-    withCredentials: true,
-  };
 
-  constructor(private http: HttpClient, private progress: ProgressBarService) {}
+  constructor(private http: HttpClient) {}
 
-  // Override GET and POST to use HttpOptions which is needed for auth
-  private async get(path: string, textResponse = false): Promise<any> {
-    this.progress.changeProgressState(true);
-
-    const request = this.http
-      .get(`${this.endpoint}${path}`, {
-        ...this.httpOptions,
-        responseType: textResponse ? ('text' as 'json') : 'json',
-      })
-      .toPromise();
-
-    request.finally(() => this.progress.changeProgressState(false));
-
-    return request;
+  private async get(path: string): Promise<any> {
+    return firstValueFrom(this.http.get(`${this.endpoint}${path}`));
   }
 
   private async post(path: string, obj: any): Promise<any> {
-    this.progress.changeProgressState(true);
-
-    let request = this.http.post(`${this.endpoint}${path}`, obj, this.httpOptions).toPromise();
-
-    if (path.includes('explore')) {
-      request = request.then(result => ({
-        requestTime: Date.now(),
-        array: result,
-      }));
-    }
-
-    request.finally(() => this.progress.changeProgressState(false));
-
-    return request;
+    return firstValueFrom(this.http.post(`${this.endpoint}${path}`, obj));
   }
 
   // GETs

--- a/src/app/services/interceptors/explore-timing-interceptor.ts
+++ b/src/app/services/interceptors/explore-timing-interceptor.ts
@@ -1,0 +1,23 @@
+import { HttpHandler, HttpInterceptor, HttpRequest, HttpResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class ExploreTimingInterceptor implements HttpInterceptor {
+  constructor() {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    return next.handle(req).pipe(
+      map(event =>
+        event instanceof HttpResponse && req.url.endsWith('explore')
+          ? event.clone({
+              body: {
+                requestTime: Date.now(),
+                array: event.body,
+              },
+            })
+          : event,
+      ),
+    );
+  }
+}

--- a/src/app/services/interceptors/http-error-interceptor.ts
+++ b/src/app/services/interceptors/http-error-interceptor.ts
@@ -1,0 +1,28 @@
+import {
+  HttpErrorResponse,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponse,
+  HttpEvent,
+} from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+  constructor() {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    return next.handle(req).pipe(
+      catchError(err => {
+        if (err instanceof HttpErrorResponse) {
+          console.warn(`${req.method} request to ${req.url} failed with`, err);
+          return of(new HttpResponse({ body: undefined, status: 200 }));
+        }
+        throw err;
+      }),
+    );
+  }
+}

--- a/src/app/services/interceptors/http-options-interceptor.ts
+++ b/src/app/services/interceptors/http-options-interceptor.ts
@@ -1,0 +1,16 @@
+import { HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class HttpOptionsInterceptor implements HttpInterceptor {
+  constructor() {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    const modifiedReq = req.clone({
+      withCredentials: true,
+      headers: req.headers.set('Content-Type', 'application/json'),
+    });
+
+    return next.handle(modifiedReq);
+  }
+}

--- a/src/app/services/interceptors/request-progress-interceptor.ts
+++ b/src/app/services/interceptors/request-progress-interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { finalize } from 'rxjs/operators';
+import { ProgressBarService } from '../progress-bar.service';
+
+@Injectable()
+export class RequestProgressInterceptor implements HttpInterceptor {
+  constructor(private progress: ProgressBarService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler) {
+    this.progress.changeProgressState(true);
+    return next.handle(req).pipe(
+      finalize(() => {
+        this.progress.changeProgressState(false);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
Previously, inside `BackendService` we used a `get` and `post` method to patch the requests made by Angular `HttpClient` with:
- correct `withCredentials` and `Content-Type`-Header values
- revealing and hiding the progress bar
- adding timing to Explore-page requests

To improve extensibility of `BackendService`, all of these features have been moved to Angular `HttpInterceptor` services.
- `ExploreTimingInterceptor`
- `HttpOptionsInterceptor`
- `RequestProgressInterceptor`

Additionally, HTTP error responses will now be logged and have their response body swapped with `undefined` in a new `HttpErrorInterceptor`.
This was done to prevent having to `.catch()` errors everywhere in the application and make response data easily `await`able, as data either exists or not, while still receiving error information in the developer console.