### PR TITLE
fix empty Contact link

### DIFF
--- a/src/app/pages/static-pages/consortium/consortium.component.html
+++ b/src/app/pages/static-pages/consortium/consortium.component.html
@@ -41,5 +41,5 @@
     30159 Hannover<br /><br />
   </p>
 
-  <p>For individual contacts, consult the <a routerLink="/contact">Contact</a> Page.</p>"
+  <p>For individual contacts, consult the <a routerLink="/about">About</a> Page.</p>
 </div>


### PR DESCRIPTION
at the Consortium page, the Contact link leaded to an empty page. 
Now it leads correctly to the About page.
removed " at the end of the page.