### PR TITLE
Add more filter options to the admin page and display possible users in a table

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { CommonModule } from '@angular/common';
+import { CommonModule, DATE_PIPE_DEFAULT_OPTIONS } from '@angular/common';
 import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { APP_INITIALIZER, Provider, importProvidersFrom } from '@angular/core';
+import { APP_INITIALIZER, LOCALE_ID, Provider, importProvidersFrom } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatButtonModule } from '@angular/material/button';
@@ -49,6 +49,7 @@ const INTERCEPTORS: Provider[] = [
 
 import { ApplicationConfig } from '@angular/core';
 import { routes } from './app.routes';
+import { MatSortModule } from '@angular/material/sort';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -72,6 +73,7 @@ export const appConfig: ApplicationConfig = {
       MatStepperModule,
       MatSlideToggleModule,
       MatTableModule,
+      MatSortModule,
       MatTabsModule,
       MatChipsModule,
       MatCheckboxModule,
@@ -93,6 +95,14 @@ export const appConfig: ApplicationConfig = {
       deps: [TranslateService],
       useClass: RouteReuse,
       multi: true,
+    },
+    {
+      provide: DATE_PIPE_DEFAULT_OPTIONS,
+      useValue: { dateFormat: 'full' },
+    },
+    {
+      provide: LOCALE_ID,
+      useValue: 'en-US',
     },
     ...INTERCEPTORS,
     provideRouter(routes),

--- a/src/app/pages/admin-page/admin-page.component.html
+++ b/src/app/pages/admin-page/admin-page.component.html
@@ -4,50 +4,140 @@
     <h2>{{ 'Waiting for admin data' | translate }}</h2>
   } @else {
     <h1>{{ 'User Administration' | translate }}</h1>
-    @if (users.length > 0) {
+    <p>
+      {{
+        'This page allows you to manage users. You can see all users, change their roles and see their objects and collections.'
+          | translate
+      }}
+      <br />
+      {{ 'Use the search below to filter by a users full name, username or mail.' | translate }}
+    </p>
+
+    <div class="filters">
       <mat-form-field>
         <input
           type="text"
           matInput
-          placeholder="{{ 'Select a user' | translate }}"
-          [matAutocomplete]="userAutoComplete"
+          placeholder="{{ 'Filter users' | translate }}"
           (input)="changeSearchInput($event)"
-          />
+        />
       </mat-form-field>
-      <mat-autocomplete
-        #userAutoComplete="matAutocomplete"
-        [displayWith]="displayName"
-        (optionSelected)="userSelected($event)"
+
+      <mat-radio-group (change)="roleFilter$.next($event.value)">
+        <mat-radio-button value="all" checked>All roles</mat-radio-button>
+        <mat-radio-button value="admin">Admin</mat-radio-button>
+        <mat-radio-button value="user">User</mat-radio-button>
+        <mat-radio-button value="uploadrequested">Upload requested</mat-radio-button>
+        <mat-radio-button value="uploader">Uploader</mat-radio-button>
+      </mat-radio-group>
+    </div>
+
+    <table
+      mat-table
+      [dataSource]="dataSource"
+      style="border: solid 1px lightgray"
+      matSort
+      matSortActive="createdAt"
+      matSortDirection="desc"
+    >
+      <ng-container matColumnDef="fullname">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          sortActionDescription="{{ 'Sort by full name' | translate }}"
         >
-        @for (user of autocompleteUsers; track user) {
-          <mat-option [value]="user">{{
-            user.fullname
-          }}</mat-option>
-        }
-      </mat-autocomplete>
-      @if (selectedUser) {
-        <h2>{{ 'Showing information about' | translate }} {{ selectedUser.fullname }}</h2>
-        <h4>{{ 'Full name' | translate }}: {{ selectedUser.fullname }}</h4>
-        <span id="role-field">
-          <span>{{ 'Role' | translate }}: {{ selectedUser.role }}</span>
-          <mat-form-field>
-            <mat-select [(value)]="selectedRole">
-              <mat-option value="user">{{ 'User' | translate }}</mat-option>
-              <mat-option value="uploader">{{ 'Uploader' | translate }}</mat-option>
-            </mat-select>
-          </mat-form-field>
-          <button mat-raised-button (click)="updateUserRole()">
-            {{ 'Change user role' | translate }}
+          {{ 'Full name' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let user">{{ user.fullname }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="username">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          sortActionDescription="{{ 'Sort by username' | translate }}"
+        >
+          {{ 'Username' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let user">{{ user.username }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="mail">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          sortActionDescription="{{ 'Sort by mail' | translate }}"
+        >
+          {{ 'Mail' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let user">{{ user.mail }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="role">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          sortActionDescription="{{ 'Sort by role' | translate }}"
+        >
+          {{ 'Role' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let user">{{ user.role }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="createdAt">
+        <th
+          mat-header-cell
+          *matHeaderCellDef
+          mat-sort-header
+          sortActionDescription="{{ 'Sort by created at' | translate }}"
+        >
+          {{ 'Created at' | translate }}
+        </th>
+        <td mat-cell *matCellDef="let user">{{ user.createdAt | date: 'short' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef>{{ 'Actions' | translate }}</th>
+        <td mat-cell *matCellDef="let user">
+          <button mat-stroked-button (click)="selectUser(user)">
+            {{ 'Show details' | translate }}
           </button>
-        </span>
-        <h4>{{ 'Username' | translate }}: {{ selectedUser.username }}</h4>
-        <h4>{{ 'Mail' | translate }}: {{ selectedUser.mail }}</h4>
-        <h4>{{ 'ID' | translate }}: {{ selectedUser._id }}</h4>
-        <mat-tab-group>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+    <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+
+    @if (selectedUser$ | async; as selectedUser) {
+      <h2>{{ 'Showing information about' | translate }} {{ selectedUser.fullname }}</h2>
+      <h4>{{ 'Full name' | translate }}: {{ selectedUser.fullname }}</h4>
+      <span id="role-field">
+        <span>{{ 'Role' | translate }}: {{ selectedUser.role }}</span>
+        <mat-form-field>
+          <mat-select (selectionChange)="selectedRole$.next($event.value)">
+            <mat-option value="user">{{ 'User' | translate }}</mat-option>
+            <mat-option value="uploader">{{ 'Uploader' | translate }}</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <button mat-raised-button (click)="updateUserRole()">
+          {{ 'Change user role' | translate }}
+        </button>
+      </span>
+      <h4>{{ 'Username' | translate }}: {{ selectedUser.username }}</h4>
+      <h4>{{ 'Mail' | translate }}: {{ selectedUser.mail }}</h4>
+      <h4>{{ 'ID' | translate }}: {{ selectedUser._id }}</h4>
+      <mat-tab-group>
+        @if (entities$ | async; as entities) {
           <mat-tab label="{{ 'Objects' | translate }}">
             <h4>{{ 'Showing' | translate }} {{ entities.length }} {{ 'objects' | translate }}</h4>
             <div class="grid">
-              @for (entity of entities; track entity) {
+              @for (entity of entities; track entity._id) {
                 <div class="grid-element">
                   <h6>{{ 'Title' | translate }}: {{ entity.name }}</h6>
                   <h6>{{ 'Type' | translate }}: {{ entity.mediaType }}</h6>
@@ -58,18 +148,24 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (compilations$ | async; as compilations) {
           <mat-tab label="{{ 'Collections' | translate }}">
-            <h4>{{ 'Showing' | translate }} {{ compilations.length }} {{ 'objects' | translate }}</h4>
+            <h4>
+              {{ 'Showing' | translate }} {{ compilations.length }} {{ 'objects' | translate }}
+            </h4>
             <div class="grid">
-              @for (compilation of compilations; track compilation) {
-                <div
-                  class="grid-element"
-                  >
+              @for (compilation of compilations; track compilation._id) {
+                <div class="grid-element">
                   <h6>{{ 'Title' | translate }}: {{ compilation.name }}</h6>
                   <h6>{{ 'Description' | translate }}: {{ compilation.description }}</h6>
                   <h6># {{ 'of objects' | translate }}: {{ compilation.entities.length }}</h6>
-                  <h6># {{ 'of annotations' | translate }}: {{ compilation.annotations.length }}</h6>
-                  <h6>{{ 'Whitelist enabled' | translate }}: {{ compilation.whitelist.enabled }}</h6>
+                  <h6>
+                    # {{ 'of annotations' | translate }}: {{ compilation.annotations.length }}
+                  </h6>
+                  <h6>
+                    {{ 'Whitelist enabled' | translate }}: {{ compilation.whitelist.enabled }}
+                  </h6>
                   <h6>
                     # {{ 'of whitelisted persons' | translate }}:
                     {{ compilation.whitelist.groups.length }}
@@ -83,10 +179,12 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (tags$ | async; as tags) {
           <mat-tab label="{{ 'Tags' | translate }}">
             <h4>{{ 'Showing' | translate }} {{ tags.length }} {{ 'objects' | translate }}</h4>
             <div class="grid">
-              @for (tag of tags; track tag) {
+              @for (tag of tags; track tag._id) {
                 <div class="grid-element">
                   <h6>{{ 'Value' | translate }}: {{ tag.value }}</h6>
                   <h6>{{ 'ID' | translate }}: {{ tag._id }}</h6>
@@ -94,10 +192,12 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (persons$ | async; as persons) {
           <mat-tab label="{{ 'Persons' | translate }}">
             <h4>{{ 'Showing' | translate }} {{ persons.length }} {{ 'objects' | translate }}</h4>
             <div class="grid">
-              @for (person of persons; track person) {
+              @for (person of persons; track person._id) {
                 <div class="grid-element">
                   <h6>{{ 'Name' | translate }}: {{ person.prename }} {{ person.name }}</h6>
                   <h6>{{ 'ID' | translate }}: {{ person._id }}</h6>
@@ -105,31 +205,37 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (institutions$ | async; as institutions) {
           <mat-tab label="{{ 'Institutions' | translate }}">
-            <h4>{{ 'Showing' | translate }} {{ institutions.length }} {{ 'objects' | translate }}</h4>
+            <h4>
+              {{ 'Showing' | translate }} {{ institutions.length }} {{ 'objects' | translate }}
+            </h4>
             <div class="grid">
-              @for (institution of institutions; track institution) {
-                <div
-                  class="grid-element"
-                  >
+              @for (institution of institutions; track institution._id) {
+                <div class="grid-element">
                   <h6>{{ 'Name' | translate }}: {{ institution.name }}</h6>
                   @if (institution.university !== '') {
-                    <h6>
-                      {{ 'University' | translate }}: {{ institution.university }}
-                    </h6>
+                    <h6>{{ 'University' | translate }}: {{ institution.university }}</h6>
                   }
                   <h6>{{ 'ID' | translate }}: {{ institution._id }}</h6>
                 </div>
               }
             </div>
           </mat-tab>
+        }
+        @if (annotations$ | async; as annotations) {
           <mat-tab label="{{ 'Annotations' | translate }}">
-            <h4>{{ 'Showing' | translate }} {{ annotations.length }} {{ 'objects' | translate }}</h4>
+            <h4>
+              {{ 'Showing' | translate }} {{ annotations.length }} {{ 'objects' | translate }}
+            </h4>
             <div class="grid">
-              @for (annotation of annotations; track annotation) {
+              @for (annotation of annotations; track annotation._id) {
                 <div class="grid-element">
                   <h6>{{ 'Title' | translate }}: {{ annotation.body.content.title }}</h6>
-                  <h6>{{ 'Description' | translate }}: {{ annotation.body.content.description }}</h6>
+                  <h6>
+                    {{ 'Description' | translate }}: {{ annotation.body.content.description }}
+                  </h6>
                   <h6>
                     {{ 'Target object' | translate }}: {{ annotation.target.source.relatedEntity }}
                   </h6>
@@ -144,10 +250,12 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (groups$ | async; as groups) {
           <mat-tab label="{{ 'Groups' | translate }}">
             <h4>{{ 'Showing' | translate }} {{ groups.length }} {{ 'objects' | translate }}</h4>
             <div class="grid">
-              @for (group of groups; track group) {
+              @for (group of groups; track group._id) {
                 <div class="grid-element">
                   <h6>{{ 'Name' | translate }}: {{ group.name }}</h6>
                   <h6># {{ 'of members' | translate }}: {{ group.members.length }}</h6>
@@ -157,10 +265,12 @@
               }
             </div>
           </mat-tab>
+        }
+        @if (metadata$ | async; as metadata) {
           <mat-tab label="{{ 'Metadata' | translate }}">
             <h4>{{ 'Showing' | translate }} {{ metadata.length }} {{ 'objects' | translate }}</h4>
             <div class="grid">
-              @for (data of metadata; track data) {
+              @for (data of metadata; track data._id) {
                 <div class="grid-element">
                   <h6>{{ 'Title' | translate }}: {{ data.title }}</h6>
                   <h6>{{ 'Description' | translate }}: {{ data.description }}</h6>
@@ -169,8 +279,8 @@
               }
             </div>
           </mat-tab>
-        </mat-tab-group>
-      }
+        }
+      </mat-tab-group>
     }
   }
 </div>

--- a/src/app/pages/admin-page/admin-page.component.scss
+++ b/src/app/pages/admin-page/admin-page.component.scss
@@ -1,3 +1,24 @@
+:host {
+  display: flex;
+  align-items: center;
+  .content {
+    display: flex;
+    flex-direction: column;
+    width: 1280px;
+  }
+
+  .filters {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+
+    mat-form-field {
+      flex-grow: 1;
+    }
+  }
+}
+
 .grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
@@ -13,9 +34,4 @@
   * {
     padding-right: 2rem;
   }
-}
-
-.content {
-  display: flex;
-  flex-direction: column;
 }

--- a/src/app/pages/admin-page/admin-page.component.ts
+++ b/src/app/pages/admin-page/admin-page.component.ts
@@ -1,11 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit, viewChild, ViewChild } from '@angular/core';
 import {
   MatAutocomplete,
   MatAutocompleteSelectedEvent,
   MatAutocompleteTrigger,
 } from '@angular/material/autocomplete';
 import { Meta, Title } from '@angular/platform-browser';
-import { combineLatest } from 'rxjs';
+import { BehaviorSubject, combineLatest, combineLatestWith, map, startWith } from 'rxjs';
 
 import { AccountService, BackendService, DialogHelperService } from 'src/app/services';
 import {
@@ -18,9 +18,10 @@ import {
   IPerson,
   ITag,
   IUserData,
+  ObjectId,
 } from 'src/common';
 
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { MatButton } from '@angular/material/button';
 import { MatOption } from '@angular/material/core';
 import { MatFormField } from '@angular/material/form-field';
@@ -28,6 +29,21 @@ import { MatInput } from '@angular/material/input';
 import { MatSelect } from '@angular/material/select';
 import { MatTab, MatTabGroup } from '@angular/material/tabs';
 import { TranslatePipe } from '../../pipes/translate.pipe';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatTable, MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { MatSort, MatSortModule } from '@angular/material/sort';
+import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatRadioModule } from '@angular/material/radio';
+
+const getTimestampFromObjectId = (objectId: string) => {
+  return new Date(parseInt(objectId.substring(0, 8), 16) * 1000);
+};
+
+const uniqueArrayByObjectId = <T extends { _id: string | ObjectId }>(array: T[]) => {
+  return array.filter((value, index, self) => {
+    return self.findIndex(t => t._id.toString() === value._id.toString()) === index;
+  });
+};
 
 @Component({
   selector: 'app-admin-page',
@@ -37,8 +53,13 @@ import { TranslatePipe } from '../../pipes/translate.pipe';
   imports: [
     MatFormField,
     MatInput,
+    MatChipsModule,
     MatAutocompleteTrigger,
     MatAutocomplete,
+    MatTableModule,
+    MatPaginatorModule,
+    MatSortModule,
+    MatRadioModule,
     MatOption,
     MatSelect,
     MatButton,
@@ -46,19 +67,33 @@ import { TranslatePipe } from '../../pipes/translate.pipe';
     MatTab,
     AsyncPipe,
     TranslatePipe,
+    DatePipe,
   ],
 })
 export class AdminPageComponent implements OnInit {
+  public sort = viewChild(MatSort);
+  public paginator = viewChild(MatPaginator);
+
   private fetchedData = false;
 
-  public users: IUserData[] = [];
-  public selectedUser: IUserData | undefined;
+  public users$ = new BehaviorSubject<IUserData[]>([]);
+  public selectedUser$ = new BehaviorSubject<IUserData | undefined>(undefined);
 
-  public selectedRole = 'user';
+  public selectedRole$ = new BehaviorSubject<string>('user');
+  public roleFilter$ = new BehaviorSubject<string>('all');
 
-  public userSearchInput = '';
+  public dataSource = new MatTableDataSource<IUserData & { createdAt: Date }>([]);
 
   private loginData?: { username: string; password: string };
+
+  public displayedColumns: string[] = [
+    'fullname',
+    'username',
+    'mail',
+    'role',
+    'createdAt',
+    'actions',
+  ];
 
   constructor(
     private account: AccountService,
@@ -67,7 +102,7 @@ export class AdminPageComponent implements OnInit {
     private metaService: Meta,
     private helper: DialogHelperService,
   ) {
-    combineLatest(this.account.isAuthenticated$, this.account.isAdmin$).subscribe(
+    combineLatest([this.account.isAuthenticated$, this.account.isAdmin$]).subscribe(
       ([authenticated, admin]) => {
         if (!authenticated) {
           console.error('User is not authenticated');
@@ -106,21 +141,26 @@ export class AdminPageComponent implements OnInit {
     }
     const { username, password } = loginData;
 
-    await this.backend.getAllUsers(username, password).then(result => (this.users = result));
+    await this.backend.getAllUsers(username, password).then(result => this.users$.next(result));
   }
 
-  public changeSearchInput = (event: Event) => {
-    const value = (event.target as HTMLInputElement).value;
-    if (!value) return;
-    this.userSearchInput = value.toLowerCase();
-  };
+  public updateFilter(filter: string, role = 'all') {
+    const removedRoleFilter = filter.replace(/\s?role:\w+\s?/g, '');
+    this.dataSource.filter = [removedRoleFilter.toLowerCase(), `role:${role}`]
+      .filter(v => !!v)
+      .join(' ');
+    console.log('filter', this.dataSource.filter);
+  }
+
+  public changeSearchInput(event: Event) {
+    this.updateFilter((event.target as HTMLInputElement).value?.toString() ?? '');
+  }
 
   displayName(user: IUserData) {
     return user.fullname;
   }
 
-  public async userSelected(event: MatAutocompleteSelectedEvent) {
-    let user: IUserData = event.option.value;
+  public async selectUser(user?: IUserData) {
     if (!user) return;
 
     const loginData = await this.getLoginData();
@@ -131,70 +171,119 @@ export class AdminPageComponent implements OnInit {
 
     if (!user) return;
 
-    this.selectedUser = user;
+    this.selectedUser$.next(user);
   }
 
   public async updateUserRole() {
-    if (!this.selectedUser) return;
-    console.log(this.selectedRole);
+    const selectedUser = this.selectedUser$.getValue();
+    if (!selectedUser) return;
+    const selectedRole = this.selectedRole$.getValue();
 
     const loginData = await this.getLoginData();
     if (!loginData) return;
     const { username, password } = loginData;
 
     await this.backend
-      .promoteUser(username, password, this.selectedUser._id, this.selectedRole)
+      .promoteUser(username, password, selectedUser._id, selectedRole)
       .then(result => console.log(result));
 
     const user = await this.backend
-      .getUser(username, password, this.selectedUser._id)
+      .getUser(username, password, selectedUser._id)
       .then(result => result);
 
     if (!user) return;
 
-    this.selectedUser = user;
+    this.selectedUser$.next(user);
   }
 
-  get entities(): IEntity[] {
-    return this.selectedUser?.data?.entity ?? [];
+  get entities$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.entity ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get compilations(): ICompilation[] {
-    return this.selectedUser?.data?.compilation ?? [];
+  get compilations$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.compilation ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get tags(): ITag[] {
-    return this.selectedUser?.data?.tag ?? [];
+  get tags$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.tag ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get persons(): IPerson[] {
-    return this.selectedUser?.data?.person ?? [];
+  get persons$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.person ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get institutions(): IInstitution[] {
-    return this.selectedUser?.data?.institution ?? [];
+  get institutions$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.institution ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get annotations(): IAnnotation[] {
-    return this.selectedUser?.data?.annotation ?? [];
+  get annotations$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.annotation ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get groups(): IGroup[] {
-    return this.selectedUser?.data?.group ?? [];
+  get groups$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.group ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
+    );
   }
 
-  get metadata(): IDigitalEntity[] {
-    return this.selectedUser?.data?.digitalentity ?? [];
-  }
-
-  get autocompleteUsers() {
-    return this.users.filter(_u =>
-      this.userSearchInput === '' ? true : _u.fullname.toLowerCase().includes(this.userSearchInput),
+  get metadata$() {
+    return this.selectedUser$.pipe(
+      map(user => user?.data?.digitalentity ?? []),
+      map(arr => uniqueArrayByObjectId(arr)),
     );
   }
 
   ngOnInit() {
     this.titleService.setTitle('Kompakkt – Admin');
     this.metaService.updateTag({ name: 'description', content: 'Admin area.' });
+
+    this.dataSource.filterPredicate = (user, filter) => {
+      const words = filter.split(/\s+/).filter(word => word.length > 0);
+      const role = words.find(word => word.startsWith('role:'))?.replace('role:', '');
+      if (role && role !== 'all' && user.role !== role) return false;
+      const pattern = words
+        .filter(word => !word.startsWith('role:'))
+        .map(word => `(${word})`)
+        .join('.*');
+      const regex = new RegExp(pattern, 'i');
+      return regex.test([user.fullname, user.username, user.mail].join(' '));
+    };
+
+    this.roleFilter$.subscribe(role => {
+      this.updateFilter(this.dataSource.filter, role);
+    });
+
+    this.users$.pipe(map(arr => uniqueArrayByObjectId(arr))).subscribe(users => {
+      const sort = this.sort();
+      if (sort) {
+        this.dataSource.sort = sort;
+      }
+      const paginator = this.paginator();
+      if (paginator) this.dataSource.paginator = paginator;
+      const withDate = users.map(user => ({
+        ...user,
+        createdAt: getTimestampFromObjectId(user._id.toString()),
+      }));
+      this.dataSource.data = withDate;
+    });
   }
 }


### PR DESCRIPTION
While the admin page is only really used for giving users upload permission, finding the right users to change permissions was unnecessarily difficult.

This PR enhances the admin page by adding filter options and displaying users in a sortable and pageable table.

[Screencast From 2024-10-24 22-17-37.webm](https://github.com/user-attachments/assets/c1484537-675a-4dc0-8385-1cea49f5d1da)
