### PR TITLE
Modernize EntityRightsDialogComponent

### DIFF
--- a/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.html
+++ b/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.html
@@ -1,41 +1,62 @@
-@if (!entity) {
-  <h3>{{ 'No object passed' | translate }}</h3>
-}
+<h2 class="title-with-button">
+  <span>{{ 'Object owners' | translate }}</span>
+  <button mat-icon-button id="close-entity-rights-dialog" [mat-dialog-close]="true">
+    <mat-icon>close</mat-icon>
+  </button>
+</h2>
 
-@if (entity) {
-  <div id="container">
-    <button mat-icon-button id="close-entity-rights-dialog" [mat-dialog-close]="true">
-      <mat-icon>close</mat-icon>
-    </button>
-    <h3>{{ 'Object owners' | translate }}</h3>
-    <p>
-      {{ 'Note: People listed here will have the same rights of this object as you, including editing metadata, changing visibility and deleting the object.' | translate }}
-    </p>
+@if (entity$ | async; as entity) {
+  <p>
+    {{
+      'Note: People listed here will have the same rights of this object as you, including editing metadata, changing visibility and deleting the object.'
+        | translate
+    }}
+  </p>
+  <p>
+    {{
+      'When adding or removing, you will be prompted to confirm the action. Changes are immediate'
+        | translate
+    }}
+  </p>
+  @if (filteredAccounts$ | async; as filteredAccounts) {
     <mat-form-field>
       <mat-label>{{ 'Search for a user' | translate }}</mat-label>
-      <input matInput [matAutocomplete]="userAuto" />
+      <input matInput [formControl]="searchControl" [matAutocomplete]="userAuto" #searchInput />
     </mat-form-field>
-    <mat-autocomplete #userAuto="matAutocomplete" (optionSelected)="userSelected($event)">
-      @for (account of allAccounts; track account) {
-        <mat-option [value]="account">
-          {{ account.fullname }} - {{ account.username }}
-        </mat-option>
+    <mat-autocomplete
+      #userAuto="matAutocomplete"
+      (optionSelected)="searchInput.value = ''; userSelected($event)"
+    >
+      @for (account of filteredAccounts; track account._id) {
+        <mat-option [value]="account"> {{ account.fullname }} - {{ account.username }} </mat-option>
       }
     </mat-autocomplete>
-    <mat-list>
-      @for (owner of entityOwners; track owner) {
-        <mat-list-item>
-          <span>{{ owner.fullname }} - {{ owner.username }}</span>
+  } @else {
+    <p>Fetching accounts...</p>
+  }
+  @if (entityOwners$ | async; as entityOwners) {
+    @for (owner of entityOwners; track owner._id) {
+      <div class="owner">
+        @if (strippedUser$ | async; as strippedUser) {
           @if (strippedUser && owner._id !== strippedUser._id) {
-            <button
-              mat-icon-button
-              (click)="removeUser(owner)"
-              >
+            <button mat-icon-button (click)="removeUser(owner)">
               <mat-icon>delete</mat-icon>
             </button>
+          } @else {
+            <button
+              mat-icon-button
+              [matTooltip]="'You cannot remove permission for yourself' | translate"
+            >
+              <mat-icon>warning</mat-icon>
+            </button>
           }
-        </mat-list-item>
-      }
-    </mat-list>
-  </div>
+        }
+        <span>{{ owner.fullname }} - {{ owner.username }}</span>
+      </div>
+    }
+  } @else {
+    <p>Fetching owners...</p>
+  }
+} @else {
+  <p>{{ 'No object passed' | translate }}</p>
 }

--- a/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.scss
+++ b/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.scss
@@ -1,11 +1,19 @@
-#close-entity-rights-dialog {
-  margin-top: -15px;
-  margin-right: -10px;
-  margin-bottom: 10px;
-  background-color: #ddd;
-  float: right;
+h2.title-with-button {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0;
 }
 
-#container {
+:host {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
   max-width: 50rem;
+}
+
+div.owner {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 }

--- a/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.ts
+++ b/src/app/dialogs/entity-rights-dialog/entity-rights-dialog.component.ts
@@ -1,20 +1,34 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, inject, Inject, OnInit } from '@angular/core';
 import {
-  MatAutocomplete,
+  MatAutocompleteModule,
   MatAutocompleteSelectedEvent,
-  MatAutocompleteTrigger,
 } from '@angular/material/autocomplete';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogClose } from '@angular/material/dialog';
 
 import { MatIconButton } from '@angular/material/button';
 import { MatOption } from '@angular/material/core';
 import { MatFormField } from '@angular/material/form-field';
-import { MatIcon } from '@angular/material/icon';
+import { MatIcon, MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { MatList, MatListItem } from '@angular/material/list';
+import { MatList, MatListItem, MatListModule } from '@angular/material/list';
 import { AccountService, BackendService, DialogHelperService } from 'src/app/services';
 import { IEntity, IStrippedUserData } from 'src/common';
 import { TranslatePipe } from '../../pipes/translate.pipe';
+import { MatSelectModule } from '@angular/material/select';
+import {
+  BehaviorSubject,
+  catchError,
+  combineLatestWith,
+  filter,
+  from,
+  map,
+  of,
+  startWith,
+  switchMap,
+} from 'rxjs';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-entity-rights-dialog',
@@ -22,46 +36,80 @@ import { TranslatePipe } from '../../pipes/translate.pipe';
   styleUrls: ['./entity-rights-dialog.component.scss'],
   standalone: true,
   imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
     MatIconButton,
     MatDialogClose,
-    MatIcon,
+    MatIconModule,
     MatFormField,
     MatInputModule,
-    MatAutocompleteTrigger,
-    MatAutocomplete,
-    MatOption,
-    MatList,
-    MatListItem,
+    MatAutocompleteModule,
+    MatSelectModule,
+    MatTooltipModule,
     TranslatePipe,
   ],
 })
 export class EntityRightsDialogComponent implements OnInit {
-  public entity?: IEntity;
+  private dialog = inject(MatDialog);
+  private data = inject<IEntity | undefined>(MAT_DIALOG_DATA);
+  private backend = inject(BackendService);
+  private account = inject(AccountService);
+  private helper = inject(DialogHelperService);
 
-  public entityOwners: IStrippedUserData[] = [];
-  public strippedUser?: IStrippedUserData;
+  public searchControl = new FormControl('');
 
-  public allAccounts: IStrippedUserData[] = [];
+  public entity$ = new BehaviorSubject<IEntity | undefined>(undefined);
+  private entityOwnerChanges$ = new BehaviorSubject<
+    {
+      action: 'add' | 'remove';
+      user: IStrippedUserData;
+    }[]
+  >([]);
+  public entityOwners$ = this.entity$.pipe(
+    filter((obj): obj is IEntity => !!obj?._id),
+    switchMap(({ _id }) => this.backend.findEntityOwners(_id.toString())),
+    catchError(err => {
+      console.error('Failed fetching entity owners', err);
+      return of<IStrippedUserData[]>([]);
+    }),
+    combineLatestWith(this.entityOwnerChanges$),
+    map(([owners, changes]) => {
+      changes.forEach(({ action, user }) => {
+        if (action === 'add') owners.push(user);
+        else owners = owners.filter(_u => _u._id !== user._id);
+      });
+      return owners;
+    }),
+  );
+  public strippedUser$ = this.account.strippedUser$;
 
-  constructor(
-    private dialog: MatDialog,
-    @Inject(MAT_DIALOG_DATA) private data: IEntity | undefined,
-    private backend: BackendService,
-    private account: AccountService,
-    private helper: DialogHelperService,
-  ) {
-    this.account.strippedUser$.subscribe(strippedUser => {
-      this.strippedUser = strippedUser;
-    });
-    this.backend
-      .getAccounts()
-      .then(result => (this.allAccounts = result))
-      .catch(e => console.error(e));
-  }
+  public allAccounts$ = from(this.backend.getAccounts()).pipe(
+    catchError(err => {
+      console.error('Failed fetching accounts', err);
+      return of<IStrippedUserData[]>([]);
+    }),
+  );
+  public filteredAccounts$ = this.allAccounts$.pipe(
+    combineLatestWith(
+      this.searchControl.valueChanges.pipe(
+        startWith(''),
+        map(value => value?.toLowerCase().trim() ?? ''),
+      ),
+      this.entityOwners$,
+    ),
+    map(([accounts, search, currentOwners]) =>
+      accounts
+        .filter(account => !currentOwners.some(owner => owner._id === account._id))
+        .filter(account => Object.values(account).join('').toLowerCase().includes(search)),
+    ),
+  );
 
   public async userSelected(event: MatAutocompleteSelectedEvent) {
-    if (!this.strippedUser) return;
-    if (!this.entity) return;
+    console.log(event.source);
+
+    const entity = this.entity$.getValue();
+    if (!entity) return;
 
     const newUser = event.option.value;
     const loginData = await this.helper.confirmWithAuth(
@@ -73,16 +121,25 @@ export class EntityRightsDialogComponent implements OnInit {
     console.log(newUser);
     const { username, password } = loginData;
 
-    // TODO: handle response
-    this.backend
-      .addEntityOwner(username, password, this.entity._id, newUser.username)
-      .then(response => this.entityOwners.push(newUser))
-      .catch(e => console.error(e));
+    const success = await this.backend
+      .addEntityOwner(username, password, entity._id, newUser.username)
+      .then(() => true)
+      .catch(e => {
+        console.error('Failed adding owner', e);
+        return false;
+      });
+    if (!success) return;
+    this.entityOwnerChanges$.next(
+      this.entityOwnerChanges$.getValue().concat({
+        action: 'add',
+        user: newUser,
+      }),
+    );
   }
 
   public async removeUser(user: IStrippedUserData) {
-    if (!this.strippedUser) return;
-    if (!this.entity) return;
+    const entity = this.entity$.getValue();
+    if (!entity) return;
 
     const loginData = await this.helper.confirmWithAuth(
       `Do you really want to remove ${user.fullname} from owners?`,
@@ -91,22 +148,23 @@ export class EntityRightsDialogComponent implements OnInit {
     if (!loginData) return;
     const { username, password } = loginData;
 
-    // TODO: handle response
-    this.backend
-      .removeEntityOwner(username, password, this.entity._id, user.username)
-      .then(response => {
-        this.entityOwners = this.entityOwners.filter(_u => _u._id !== user._id);
-      })
-      .catch(e => console.error(e));
+    const success = await this.backend
+      .removeEntityOwner(username, password, entity._id, user.username)
+      .then(() => true)
+      .catch(e => {
+        console.error('Failed removing owner', e);
+        return false;
+      });
+    if (!success) return;
+    this.entityOwnerChanges$.next(
+      this.entityOwnerChanges$.getValue().concat({
+        action: 'remove',
+        user,
+      }),
+    );
   }
 
   ngOnInit() {
-    if (this.data) {
-      this.entity = this.data;
-      this.backend
-        .findEntityOwners(this.entity._id)
-        .then(accounts => (this.entityOwners = accounts))
-        .catch(e => console.error(e));
-    }
+    if (this.data) this.entity$.next(this.data);
   }
 }


### PR DESCRIPTION
EntityRightsDialogComponent is a component used for managing owners of an entity.
It has been overlooked for a while, and was reported by @ZetOE as non-functioning.

This PR makes sure that:
- both adding and deleting owners works and shows the immediate result in the list
- filtering the account dropdown works as expected

No big design changes were done in this.