### PR TITLE
Changes the "externalLink"-display of entities to be anchor elements

### DIFF
--- a/src/app/components/entity-detail/detail-entity/detail-entity.component.html
+++ b/src/app/components/entity-detail/detail-entity/detail-entity.component.html
@@ -129,16 +129,9 @@ objecttype: string;
       </mat-expansion-panel-header>
       @for (link of externalLinks; track link) {
         <div class="block">
-          @if (link.description) {
-            <p>
-              {{ link.description }}
-            </p>
-          }
-          @if (link.description) {
-            <p>
-              {{ link.value }}
-            </p>
-          }
+          <a [href]="link.value" target="_blank" rel="noreferer noopener">
+            {{ link.description || link.value }}
+          </a>
         </div>
       }
     </mat-expansion-panel>


### PR DESCRIPTION
As reported by @ZetOE, "External Links" in metadata should be clickable links, as this is what would be expected.

This PR fixes this.