### PR TITLE
changed design of Login, Register and Help dialogs

### DIFF
--- a/src/app/components/auth-dialog/auth-dialog.component.html
+++ b/src/app/components/auth-dialog/auth-dialog.component.html
@@ -1,9 +1,21 @@
 <form [formGroup]="form" (submit)="trySubmit()" id="authForm">
-  <h3>{{ concern !== '' ? concern : ('Login' | translate) }}</h3>
+ <div class="loginDialog">
+  <div class="titleAndClose">
+    <h3>{{ concern !== '' ? concern : ('Login' | translate) }}</h3>
+    <button
+    mat-icon-button
+    class="close-dialog-button"
+    (click)="dialogRef.close(false)"
+    tabindex="-1"
+    type="button"
+    >
+    <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
   <mat-form-field class="fullwidth">
     <mat-label matRippleDisabled>{{ 'Enter your username' | translate }}</mat-label>
     <input
-     
       matInput
       type="text"
       autocomplete="username"
@@ -23,20 +35,18 @@
       required
       />
   </mat-form-field>
-  <div class="button-row">
+
+  <div class="help">
+    <div class="help-row">
+      <a href="javascript:void(0)" (click)="openForgotUsernameDialog()">{{ 'Forgot username?' | translate }}</a>
+      <a href="javascript:void(0)" (click)="openForgotPasswordDialog()">{{ 'Forgot password?' | translate }}</a>
+    </div>
+  </div>
+
+  <div class="login-btn">
     <button
-      id="btn-cancel"
-      mat-stroked-button
-      type="button"
-      color="accent"
-      (click)="dialogRef.close(false)"
-      [disabled]="waitingForResponse"
-      >
-      {{ 'Cancel' | translate }}
-    </button>
-    <button
-      id="btn-login"
-      mat-stroked-button
+      id="btn-submit"
+      mat-flat-button
       type="submit"
       color="primary"
       [disabled]="!form.valid || waitingForResponse"
@@ -44,21 +54,14 @@
       {{ 'Login' | translate }}
     </button>
   </div>
+
   <p>
     {{ 'Don’t have an account?' | translate }}
     <a href="javascript:void(0)" (click)="openRegistrationDialog()">{{ 'Register' | translate }}</a>
   </p>
+</div>
 </form>
 @if (loginFailed) {
   <div class="errors">{{ 'Failed to login.' | translate }}<br />{{ 'Check username and password.' | translate }}</div>
 }
 
-<mat-divider></mat-divider>
-
-<div class="help">
-  <h3>{{ 'Need help?' | translate }}</h3>
-  <div class="help-row">
-    <a href="javascript:void(0)" (click)="openForgotUsernameDialog()">{{ 'Forgot username?' | translate }}</a>
-    <a href="javascript:void(0)" (click)="openForgotPasswordDialog()">{{ 'Forgot password?' | translate }}</a>
-  </div>
-</div>

--- a/src/app/components/auth-dialog/auth-dialog.component.scss
+++ b/src/app/components/auth-dialog/auth-dialog.component.scss
@@ -1,7 +1,32 @@
-.button-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 1rem;
+.loginDialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+
+}
+
+.titleAndClose{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.login-btn {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+
+  button {
+    width: 100%;
+  }
+}
+
+::ng-deep .mat-mdc-form-field {
+  // Entfernt den Abstand am unteren Rand
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
 }
 
 .errors {
@@ -12,12 +37,18 @@
 .help {
   .help-row {
     display: flex;
-    justify-content: space-around;
+    justify-content: space-between;
   }
 }
 
 h3 {
-  border-left: solid var(--brand-color) 0.25rem;
-  padding-left: 0.8rem;
+  padding: 0;
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
 }
 
+p{
+  padding: 0;
+  margin: 0;
+}

--- a/src/app/components/auth-dialog/auth-dialog.component.ts
+++ b/src/app/components/auth-dialog/auth-dialog.component.ts
@@ -15,8 +15,8 @@ import {
 } from 'src/app/dialogs';
 import { AccountService } from 'src/app/services';
 import { TranslatePipe } from '../../pipes/translate.pipe';
-
-import { MatButton } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MatFormField } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatDividerModule } from '@angular/material/divider';
@@ -32,8 +32,9 @@ import { MatDividerModule } from '@angular/material/divider';
     MatFormField,
     MatInputModule,
     MatDividerModule,
-    MatButton,
+    MatButtonModule,
     TranslatePipe,
+    MatIcon,
   ],
 })
 export class AuthDialogComponent implements OnInit {

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
@@ -1,7 +1,7 @@
 <form [formGroup]="form" (submit)="trySubmit()">
   <div class="forgotPasswordDialog">
     <div class="titleAndClose">
-      <h2>{{ 'Forgot your passwoerd?' | translate }}</h2>
+      <h2>{{ 'Forgot your password?' | translate }}</h2>
       <button
         mat-icon-button
         class="close-dialog-button"

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.html
@@ -1,21 +1,35 @@
 <form [formGroup]="form" (submit)="trySubmit()">
-  <h3>{{ 'Forgot your password?' | translate }}</h3>
-  <p>{{ 'You can request your password using your username and will receive a mail!' | translate }}</p>
-  <mat-form-field class="fullwidth">
-    <mat-label>{{ 'Enter your username' | translate }}</mat-label>
-    <input
-      matInput
-      type="text"
-      autocomplete="username"
-      name="username"
-      formControlName="username"
-      required
-      />
-  </mat-form-field>
+  <div class="forgotPasswordDialog">
+    <div class="titleAndClose">
+      <h2>{{ 'Forgot your passwoerd?' | translate }}</h2>
+      <button
+        mat-icon-button
+        class="close-dialog-button"
+        (click)="dialogRef.close(false)"
+        tabindex="-1"
+        type="button"
+        >
+        <mat-icon>close</mat-icon>
+        </button>
+    </div>
+    
+    <p>{{ 'You can request your password using your username and will receive a mail!' | translate }}</p>
+    <mat-form-field class="fullwidth">
+      <mat-label>{{ 'Enter your username' | translate }}</mat-label>
+      <input
+        matInput
+        type="text"
+        autocomplete="username"
+        name="username"
+        formControlName="username"
+        required
+        />
+    </mat-form-field>
 
-  <button mat-stroked-button type="submit" color="primary" [disabled]="!form.valid">
+    <button mat-flat-button type="submit" color="primary" [disabled]="!form.valid">
     {{ 'Submit password request' | translate }}
-  </button>
+    </button>
+  </div>
 </form>
 
 @if (serverErrorMsg.length > 0) {

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.scss
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.scss
@@ -1,3 +1,17 @@
+.forgotPasswordDialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+}
+
+
+.titleAndClose{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 button {
   width: 100%;
 }
@@ -6,7 +20,14 @@ button {
   color: red;
 }
 
-h3 {
-  border-left: solid var(--brand-color) 0.25rem;
-  padding-left: 0.8rem;
+h2 {
+  padding: 0;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+p{
+  padding: 0;
+  margin: 0;
 }

--- a/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.ts
+++ b/src/app/dialogs/forgot-password-dialog/forgot-password-dialog.component.ts
@@ -12,7 +12,8 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { BackendService, SnackbarService } from 'src/app/services';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 
-import { MatButton } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MatFormField } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 
@@ -25,8 +26,9 @@ import { MatInputModule } from '@angular/material/input';
     FormsModule,
     ReactiveFormsModule,
     MatFormField,
+    MatIcon,
     MatInputModule,
-    MatButton,
+    MatButtonModule,
     TranslatePipe,
   ],
 })
@@ -40,7 +42,7 @@ export class ForgotPasswordDialogComponent implements OnInit {
   constructor(
     private backend: BackendService,
     private snackbar: SnackbarService,
-    private dialogRef: MatDialogRef<ForgotPasswordDialogComponent>,
+    public dialogRef: MatDialogRef<ForgotPasswordDialogComponent>,
   ) {}
 
   public async trySubmit() {

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
@@ -1,21 +1,34 @@
 <form [formGroup]="form" (submit)="trySubmit()">
-  <h3>{{ 'Forgot your username?' | translate }}</h3>
-  <p>{{ 'You can request your username using your mail address!' | translate }}</p>
-  <mat-form-field class="fullwidth">
-    <mat-label>{{ 'Enter your mail address' | translate }}</mat-label>
-    <input
-      matInput
-      type="text"
-      autocomplete="email"
-      name="mail"
-      formControlName="mail"
-      required
-      />
-  </mat-form-field>
+  <div class="forgotUsernameDialog">
+    <div class="titleAndClose">
+      <h2>{{ 'Forgot your username?' | translate }}</h2>
+      <button
+        mat-icon-button
+        class="close-dialog-button"
+        (click)="dialogRef.close(false)"
+        tabindex="-1"
+        type="button"
+        >
+        <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    <p>{{ 'You can request your username using your mail address!' | translate }}</p>
+    <mat-form-field class="fullwidth">
+      <mat-label>{{ 'Enter your mail address' | translate }}</mat-label>
+      <input
+       matInput
+        type="text"
+        autocomplete="email"
+        name="mail"
+        formControlName="mail"
+        required
+        />
+    </mat-form-field>
 
-  <button mat-stroked-button type="submit" color="primary" [disabled]="!form.valid">
-    {{ 'Send mail' | translate }}
-  </button>
+    <button mat-flat-button type="submit" color="primary" [disabled]="!form.valid">
+      {{ 'Send mail' | translate }}
+    </button>
+  </div>
 </form>
 
 @if (serverErrorMsg.length > 0) {

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.html
@@ -12,9 +12,9 @@
         <mat-icon>close</mat-icon>
         </button>
       </div>
-    <p>{{ 'You can request your username using your mail address!' | translate }}</p>
+    <p>{{ 'You can request your username using your e-mail address!' | translate }}</p>
     <mat-form-field class="fullwidth">
-      <mat-label>{{ 'Enter your mail address' | translate }}</mat-label>
+      <mat-label>{{ 'Enter your e-mail address' | translate }}</mat-label>
       <input
        matInput
         type="text"
@@ -26,7 +26,7 @@
     </mat-form-field>
 
     <button mat-flat-button type="submit" color="primary" [disabled]="!form.valid">
-      {{ 'Send mail' | translate }}
+      {{ 'Send e-mail' | translate }}
     </button>
   </div>
 </form>

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.scss
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.scss
@@ -1,3 +1,16 @@
+.forgotUsernameDialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
+}
+
+.titleAndClose{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 button {
   width: 100%;
 }
@@ -6,7 +19,14 @@ button {
   color: red;
 }
 
-h3 {
-  border-left: solid var(--brand-color) 0.25rem;
-  padding-left: 0.8rem;
+h2 {
+  padding: 0;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+p{
+  padding: 0;
+  margin: 0;
 }

--- a/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.ts
+++ b/src/app/dialogs/forgot-username-dialog/forgot-username-dialog.component.ts
@@ -12,7 +12,8 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { BackendService, SnackbarService } from 'src/app/services';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 
-import { MatButton } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MatFormField } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 
@@ -25,8 +26,9 @@ import { MatInputModule } from '@angular/material/input';
     FormsModule,
     ReactiveFormsModule,
     MatFormField,
+    MatIcon,
     MatInputModule,
-    MatButton,
+    MatButtonModule,
     TranslatePipe,
   ],
 })
@@ -40,13 +42,12 @@ export class ForgotUsernameDialogComponent implements OnInit {
   constructor(
     private backend: BackendService,
     private snackbar: SnackbarService,
-    private dialogRef: MatDialogRef<ForgotUsernameDialogComponent>,
+    public dialogRef: MatDialogRef<ForgotUsernameDialogComponent>,
   ) {}
 
   public async trySubmit() {
     const mail = this.form.get('mail')!.value as string;
-
-    this.backend
+    await this.backend
       .forgotUsername(mail)
       .then(() => {
         this.snackbar.showInfo('Your username has been sent to your mail!');
@@ -54,6 +55,7 @@ export class ForgotUsernameDialogComponent implements OnInit {
       })
       .catch((error: HttpErrorResponse) => (this.serverErrorMsg = error.error.toString()));
   }
+
 
   ngOnInit(): void {}
 }

--- a/src/app/dialogs/register-dialog/register-dialog.component.html
+++ b/src/app/dialogs/register-dialog/register-dialog.component.html
@@ -1,8 +1,18 @@
 <form [formGroup]="form" (submit)="trySubmit()" id="registerForm">
-  <h3>{{ 'Register' | translate }}</h3>
-  <p>
-    {{ 'Note: if you are a member of the University of Cologne you can use your University account to login and do not need to register.' | translate }}
-  </p>
+  <div class="registerDialog">
+    <div class="titleAndClose">
+      <h3>{{ 'Register' | translate }}</h3>
+      <button
+      mat-icon-button
+      class="close-dialog-button"
+      (click)="dialogRef.close(false)"
+      tabindex="-1"
+      type="button"
+      >
+      <mat-icon>close</mat-icon>
+      </button>
+    </div>
+
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'E-Mail address' | translate }}</mat-label>
     <input
@@ -13,6 +23,7 @@
       formControlName="mail"
       />
   </mat-form-field>
+
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'Given name' | translate }}</mat-label>
     <input
@@ -23,6 +34,7 @@
       formControlName="prename"
       />
   </mat-form-field>
+  
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'Last name' | translate }}</mat-label>
     <input
@@ -33,6 +45,7 @@
       formControlName="surname"
       />
   </mat-form-field>
+
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'Username' | translate }}</mat-label>
     <input
@@ -43,6 +56,7 @@
       formControlName="username"
       />
   </mat-form-field>
+
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'Password' | translate }}</mat-label>
     <input
@@ -53,6 +67,7 @@
       formControlName="password"
       />
   </mat-form-field>
+
   <mat-form-field class="fullwidth">
     <mat-label>{{ 'Repeat password' | translate }}</mat-label>
     <input
@@ -64,17 +79,9 @@
       />
   </mat-form-field>
 
-  <div class="button-row">
+  <div class="register-btn">
     <button
-      mat-stroked-button
-      (click)="dialogRef.close('cancel')"
-      color="warn"
-      [disabled]="waitingForResponse"
-      >
-      {{ 'Cancel' | translate }}
-    </button>
-    <button
-      mat-stroked-button
+      mat-flat-button
       type="submit"
       color="primary"
       [disabled]="!form.valid || waitingForResponse"
@@ -82,6 +89,11 @@
       {{ 'Create new account' | translate }}
     </button>
   </div>
+  <p>
+    {{ 'Already have an account?' | translate }}
+    <a href="javascript:void(0)" (click)="openAuthDialog()">{{ 'Login' | translate }}</a>
+  </p>
+</div>
 </form>
 
 @if (error) {

--- a/src/app/dialogs/register-dialog/register-dialog.component.scss
+++ b/src/app/dialogs/register-dialog/register-dialog.component.scss
@@ -1,17 +1,33 @@
-:host {
-  display: block;
-  max-width: 55ch;
+.registerDialog {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 320px;
 }
 
-form {
-  margin-bottom: 1.6rem;
+.titleAndClose{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
-.button-row {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: 1rem;
+::ng-deep .mat-mdc-form-field {
+  // Entfernt den Abstand am unteren Rand
+  .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
 }
+
+.register-btn {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  
+    button {
+      width: 100%;
+    }
+  }
+
 
 .errors {
   color: red;
@@ -26,6 +42,13 @@ form {
 }
 
 h3 {
-  border-left: solid var(--brand-color) 0.25rem;
-  padding-left: 0.8rem;
+  padding: 0;
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+p{
+  padding: 0;
+  margin: 0;
 }

--- a/src/app/dialogs/register-dialog/register-dialog.component.ts
+++ b/src/app/dialogs/register-dialog/register-dialog.component.ts
@@ -1,5 +1,10 @@
 import { Component } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { MatDialogRef, MatDialog } from '@angular/material/dialog';
+
+import {
+  AuthDialogComponent,
+} from 'src/app/components/auth-dialog/auth-dialog.component';
+
 import { HttpErrorResponse } from '@angular/common/http';
 import {
   FormControl,
@@ -13,7 +18,8 @@ import { AccountService, BackendService } from 'src/app/services';
 import { TranslateService } from '../../services/translate.service';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 
-import { MatButton } from '@angular/material/button';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormField } from '@angular/material/form-field';
 
@@ -27,8 +33,9 @@ import { MatFormField } from '@angular/material/form-field';
     ReactiveFormsModule,
     MatFormField,
     MatInputModule,
-    MatButton,
+    MatButtonModule,
     TranslatePipe,
+    MatIcon,
   ],
 })
 export class RegisterDialogComponent {
@@ -49,6 +56,7 @@ export class RegisterDialogComponent {
     private backend: BackendService,
     public dialogRef: MatDialogRef<RegisterDialogComponent>,
     private account: AccountService,
+    private dialog: MatDialog,
   ) {}
 
   public async trySubmit() {
@@ -88,5 +96,9 @@ export class RegisterDialogComponent {
     if (!userdata) return;
 
     this.dialogRef.close({ username, password });
+  }
+
+  public openAuthDialog() {
+    this.dialog.open(AuthDialogComponent);
   }
 }


### PR DESCRIPTION
**changed the design of Login, Register and Help dialogs**
- header fonts are aligned now, bold and size: 24px
- gaps are always 16px
- there is always one button that functions as submit button (for example "Login", "Create account", etc.)
- no cancel button, but the cancel icon 
- no info text at the register form anymore
- You can switch from Login dialog to Register dialog and vice versa
- every dialog has the same width