### PR TITLE
Remove PLY from compatible formats

### DIFF
--- a/src/app/components/upload/upload.component.html
+++ b/src/app/components/upload/upload.component.html
@@ -39,7 +39,7 @@
         <span [matTooltip]="'3D Gaussian Splatting' | translate">{{ '3DGS' | translate }}</span>
       </div>
       <span><b>.spz</b></span>
-      <span>.splat, .ply, .spx</span>
+      <span>.splat, .spx</span>
     </div>
     <div class="file-format-line" [class.disabled]="isDetermined() && !isCloud()">
       <div>

--- a/src/app/services/upload-handler.service.ts
+++ b/src/app/services/upload-handler.service.ts
@@ -32,7 +32,7 @@ interface IQFile {
 export const supportedFileFormats: Record<string, string[]> = {
   model: ['obj', 'stl', 'glb', 'gltf'],
   cloud: ['laz', 'las'],
-  splat: ['splat', 'spz', 'spx', 'ply'],
+  splat: ['splat', 'spz', 'spx'],
   image: ['jpg', 'jpeg', 'png', 'tga', 'gif', 'bmp'],
   audio: ['ogg', 'mp3', 'm4a', 'wav'],
   video: ['webm', 'mp4', 'ogv'],


### PR DESCRIPTION
PLY uploads have caused issues for users. We remove it for now, and decide in the future if we integrate it with better support.