### PR TITLE
Disable Transfer-Ownership-Button 

### DIFF
--- a/src/app/components/actionbar/actionbar.component.html
+++ b/src/app/components/actionbar/actionbar.component.html
@@ -225,7 +225,7 @@
         <span>{{ 'Visibility and access' | translate }}</span>
       </button>
     }
-    @if (isFinished()) {
+    @if (isFinished() && (element | isUserOfRole: ['owner'] : user())) {
       <button mat-menu-item (click)="openTransferOwnerDialog()">
         <mat-icon color="primary">manage_accounts</mat-icon>
         <span>{{ 'Transfer ownership' | translate }}</span>

--- a/src/app/pages/detail-page/detail-page.component.html
+++ b/src/app/pages/detail-page/detail-page.component.html
@@ -96,7 +96,7 @@
 } @else {
   <p class="center-page-text">
     {{
-      "You don't have the permission to display that object. Please talk to the owner of the object to give you access."
+      'You don’t have permission to view this object. Contact the owner to request access.'
         | translate
     }}
   </p>

--- a/src/app/pages/detail-page/detail-page.component.html
+++ b/src/app/pages/detail-page/detail-page.component.html
@@ -93,4 +93,11 @@
       }
     }
   }
+} @else {
+  <p class="center-page-text">
+    {{
+      "You don't have the permission to display that object. Please talk to the owner of the object to give you access."
+        | translate
+    }}
+  </p>
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -975,8 +975,8 @@ div.option-count-badge {
 }
 
 .tag-chip {
-  .mdc-evolution-chip-set__chips{
-    margin : 0 !important;
+  .mdc-evolution-chip-set__chips {
+    margin: 0 !important;
   }
 }
 
@@ -1035,6 +1035,8 @@ div.option-count-badge {
 
 .center-page-text {
   text-align: center;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .format-title-agents {


### PR DESCRIPTION
Disable Transfer-Ownership-Button for editors and display message when there is no permission to display an object

Issues: #278 & #277 