### PR TITLE
Add info-box for compilations

### DIFF
--- a/src/app/components/actionbar/actionbar.component.html
+++ b/src/app/components/actionbar/actionbar.component.html
@@ -133,6 +133,16 @@
         <mat-icon>share</mat-icon>
       </button>
     </div>
+
+    @if (isCompilation()) {
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="informationMenu"
+        #infoMenuTrigger="matMenuTrigger"
+      >
+        <mat-icon>info</mat-icon>
+      </button>
+    }
   }
 </mat-toolbar>
 
@@ -230,6 +240,30 @@
         <mat-icon color="primary">manage_accounts</mat-icon>
         <span>{{ 'Transfer ownership' | translate }}</span>
       </button>
+    }
+  }
+</mat-menu>
+
+<mat-menu #informationMenu="matMenu">
+  @if (element(); as element) {
+    @if (isCompilation()) {
+      <div class="actionbar-info">
+        <div class="info-header">
+          <p class="info-headline">{{ element.name }}</p>
+          <button mat-icon-button (click)="closeInfoMenu()">
+            <mat-icon class="material-symbols-outlined">close</mat-icon>
+          </button>
+        </div>
+        <p>{{ compilationDescription() }}</p>
+        <p>
+          <span class="info-bold">{{ entityCount() }}</span>
+          {{ 'objects' | translate }}
+        </p>
+        <p>
+          <span class="info-bold">{{ 'Creator: ' }}</span>
+          {{ element.creator.fullname }}
+        </p>
+      </div>
     }
   }
 </mat-menu>

--- a/src/app/components/actionbar/actionbar.component.scss
+++ b/src/app/components/actionbar/actionbar.component.scss
@@ -62,3 +62,22 @@
 .container {
   padding-top: 10px;
 }
+
+.actionbar-info {
+  padding: 30px;
+
+  .info-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .info-headline {
+    font-size: 16px !important;
+    font-weight: bold;
+  }
+
+  .info-bold {
+    font-weight: bold;
+  }
+}

--- a/src/app/components/actionbar/actionbar.component.ts
+++ b/src/app/components/actionbar/actionbar.component.ts
@@ -1,6 +1,6 @@
 import { filter, firstValueFrom, map, of, shareReplay, switchMap, tap } from 'rxjs';
 
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, input, signal, viewChild } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
@@ -14,7 +14,7 @@ import { MatInputModule } from '@angular/material/input';
 
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatMenuModule } from '@angular/material/menu';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import {
@@ -32,7 +32,6 @@ import {
   AccountService,
   AllowAnnotatingService,
   BackendService,
-  DetailPageHelperService,
   DialogHelperService,
   SelectHistoryService,
   SnackbarService,
@@ -40,6 +39,7 @@ import {
 import { IsUserOfRolePipe } from '../../pipes/is-user-of-role.pipe';
 import { TranslatePipe } from '../../pipes/translate.pipe';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { OverlayModule } from '@angular/cdk/overlay';
 
 @Component({
   selector: 'app-actionbar',
@@ -58,6 +58,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     MatProgressSpinnerModule,
     ReactiveFormsModule,
     MatOptionModule,
+    OverlayModule,
     RouterLink,
     MatMenuModule,
     TranslatePipe,
@@ -90,6 +91,16 @@ export class ActionbarComponent {
   });
 
   showUsesInCollection = computed(() => this.isEntity() && this.isDetailPage());
+
+  compilationDescription = computed(() => {
+    const element = this.element();
+    return isCompilation(element) ? element.description : '';
+  });
+
+  entityCount = computed(() => {
+    const element = this.element();
+    return isCompilation(element) && element.entities ? Object.keys(element.entities).length : 0;
+  });
 
   metadataDownload = computed(() => {
     const element = this.element();
@@ -133,6 +144,8 @@ export class ActionbarComponent {
     if (!isEntity(element)) return false;
     return !!element.options?.allowDownload;
   });
+
+  readonly infoMenuTrigger = viewChild<MatMenuTrigger>('infoMenuTrigger');
 
   constructor(
     private account: AccountService,
@@ -333,6 +346,10 @@ export class ActionbarComponent {
         .catch(error => console.error(error));
     }
     this.isUpdatingPublishState.set(false);
+  }
+
+  public closeInfoMenu() {
+    this.infoMenuTrigger()?.closeMenu();
   }
 
   public async openDownloadDialog() {


### PR DESCRIPTION
- add mat-menu for information-box
- added a method to close the infobox, despite the backdrop functionality, to ensure that closing it works as expected in mobile versions aswell

Mentioned in issue #176 